### PR TITLE
Pin doughnut-rs with tag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -723,7 +723,7 @@ dependencies = [
 [[package]]
 name = "doughnut_rs"
 version = "0.1.5"
-source = "git+https://github.com/cennznet/doughnut-rs#280df32bc5c3e34cec93072deff1cac8e42c3d20"
+source = "git+https://github.com/cennznet/doughnut-rs?tag=0.1.5#280df32bc5c3e34cec93072deff1cac8e42c3d20"
 dependencies = [
  "bit_reverse 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3144,7 +3144,7 @@ dependencies = [
 name = "sr-primitives"
 version = "1.0.0"
 dependencies = [
- "doughnut_rs 0.1.5 (git+https://github.com/cennznet/doughnut-rs)",
+ "doughnut_rs 0.1.5 (git+https://github.com/cennznet/doughnut-rs?tag=0.1.5)",
  "integer-sqrt 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5458,7 +5458,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "05f47366984d3ad862010e22c7ce81a7dbcaebbdfb37241a620f8b6596ee135c"
 "checksum discard 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 "checksum dns-parser 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c4d33be9473d06f75f58220f71f7a9317aca647dc061dbd3c361b0bef505fbea"
-"checksum doughnut_rs 0.1.5 (git+https://github.com/cennznet/doughnut-rs)" = "<none>"
+"checksum doughnut_rs 0.1.5 (git+https://github.com/cennznet/doughnut-rs?tag=0.1.5)" = "<none>"
 "checksum ed25519-dalek 1.0.0-pre.1 (registry+https://github.com/rust-lang/crates.io-index)" = "81956bcf7ef761fb4e1d88de3fa181358a0d26cbcb9755b587a08f9119824b86"
 "checksum either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3be565ca5c557d7f59e7cfcf1844f9e3033650c929c6566f511e8005f205c1d0"
 "checksum elastic-array 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "073be79b6538296faf81c631872676600616073817dd9a440c477ad09b408983"

--- a/core/sr-primitives/Cargo.toml
+++ b/core/sr-primitives/Cargo.toml
@@ -13,7 +13,7 @@ substrate-primitives = { path = "../primitives", default-features = false }
 rstd = { package = "sr-std", path = "../sr-std", default-features = false }
 runtime_io = { package = "sr-io", path = "../sr-io", default-features = false }
 log = { version = "0.4", optional = true }
-doughnut = { package = "doughnut_rs", version = "0.1.5", git = "https://github.com/cennznet/doughnut-rs", default-features = false }
+doughnut = { package = "doughnut_rs", tag = "0.1.5", git = "https://github.com/cennznet/doughnut-rs", default-features = false }
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/core/test-runtime/wasm/Cargo.lock
+++ b/core/test-runtime/wasm/Cargo.lock
@@ -504,7 +504,7 @@ dependencies = [
 [[package]]
 name = "doughnut_rs"
 version = "0.1.5"
-source = "git+https://github.com/cennznet/doughnut-rs#280df32bc5c3e34cec93072deff1cac8e42c3d20"
+source = "git+https://github.com/cennznet/doughnut-rs?tag=0.1.5#280df32bc5c3e34cec93072deff1cac8e42c3d20"
 dependencies = [
  "bit_reverse 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2191,7 +2191,7 @@ dependencies = [
 name = "sr-primitives"
 version = "1.0.0"
 dependencies = [
- "doughnut_rs 0.1.5 (git+https://github.com/cennznet/doughnut-rs)",
+ "doughnut_rs 0.1.5 (git+https://github.com/cennznet/doughnut-rs?tag=0.1.5)",
  "integer-sqrt 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3360,7 +3360,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "05f47366984d3ad862010e22c7ce81a7dbcaebbdfb37241a620f8b6596ee135c"
 "checksum discard 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 "checksum dns-parser 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c4d33be9473d06f75f58220f71f7a9317aca647dc061dbd3c361b0bef505fbea"
-"checksum doughnut_rs 0.1.5 (git+https://github.com/cennznet/doughnut-rs)" = "<none>"
+"checksum doughnut_rs 0.1.5 (git+https://github.com/cennznet/doughnut-rs?tag=0.1.5)" = "<none>"
 "checksum ed25519-dalek 1.0.0-pre.1 (registry+https://github.com/rust-lang/crates.io-index)" = "81956bcf7ef761fb4e1d88de3fa181358a0d26cbcb9755b587a08f9119824b86"
 "checksum either 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c67353c641dc847124ea1902d69bd753dee9bb3beff9aa3662ecf86c971d1fac"
 "checksum elastic-array 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "073be79b6538296faf81c631872676600616073817dd9a440c477ad09b408983"

--- a/node/runtime/wasm/Cargo.lock
+++ b/node/runtime/wasm/Cargo.lock
@@ -504,7 +504,7 @@ dependencies = [
 [[package]]
 name = "doughnut_rs"
 version = "0.1.5"
-source = "git+https://github.com/cennznet/doughnut-rs#280df32bc5c3e34cec93072deff1cac8e42c3d20"
+source = "git+https://github.com/cennznet/doughnut-rs?tag=0.1.5#280df32bc5c3e34cec93072deff1cac8e42c3d20"
 dependencies = [
  "bit_reverse 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2259,7 +2259,7 @@ dependencies = [
 name = "sr-primitives"
 version = "1.0.0"
 dependencies = [
- "doughnut_rs 0.1.5 (git+https://github.com/cennznet/doughnut-rs)",
+ "doughnut_rs 0.1.5 (git+https://github.com/cennznet/doughnut-rs?tag=0.1.5)",
  "integer-sqrt 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3620,7 +3620,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "05f47366984d3ad862010e22c7ce81a7dbcaebbdfb37241a620f8b6596ee135c"
 "checksum discard 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 "checksum dns-parser 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c4d33be9473d06f75f58220f71f7a9317aca647dc061dbd3c361b0bef505fbea"
-"checksum doughnut_rs 0.1.5 (git+https://github.com/cennznet/doughnut-rs)" = "<none>"
+"checksum doughnut_rs 0.1.5 (git+https://github.com/cennznet/doughnut-rs?tag=0.1.5)" = "<none>"
 "checksum ed25519-dalek 1.0.0-pre.1 (registry+https://github.com/rust-lang/crates.io-index)" = "81956bcf7ef761fb4e1d88de3fa181358a0d26cbcb9755b587a08f9119824b86"
 "checksum either 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c67353c641dc847124ea1902d69bd753dee9bb3beff9aa3662ecf86c971d1fac"
 "checksum elastic-array 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "073be79b6538296faf81c631872676600616073817dd9a440c477ad09b408983"


### PR DESCRIPTION
Turns out `version` doesn't work with `git` if there is an update, cargo only tries the latest commit.  
This will help a little with cennznet builds downstream